### PR TITLE
Fix url in storage

### DIFF
--- a/django_upyun/storage.py
+++ b/django_upyun/storage.py
@@ -88,7 +88,7 @@ class UpYunStorage(Storage):
             raise IOError("UpYunStorageError: Unknown Error when read file, code %s" % resp.status_code)
 
     def url(self, name):
-        return name
+        return 'http://%s.b0.upaiyun.com/%s' % (self.bucket, name)
 
 
 class UpYunFile(File):


### PR DESCRIPTION
It will be used by `django.contrib.staticfiles.storage` module to generate URLs for files in templates.

Templates can be written like this:

```
{% load staticfiles %}
<link rel="stylesheet" href="{% static "css/bootstrap.css" %}">
```
